### PR TITLE
Update with 0 at the end of each update call.

### DIFF
--- a/src/cpp/Core/EffekseerManagerCore.cpp
+++ b/src/cpp/Core/EffekseerManagerCore.cpp
@@ -205,6 +205,7 @@ void EffekseerManagerCore::Update(float deltaFrames)
 	{
 		manager_->Update(1);
 	}
+	manager_->Update(0);
 }
 
 int EffekseerManagerCore::Play(EffekseerEffectCore* effect)

--- a/src/cpp/Core/EffekseerManagerCore.cpp
+++ b/src/cpp/Core/EffekseerManagerCore.cpp
@@ -205,7 +205,7 @@ void EffekseerManagerCore::Update(float deltaFrames)
 	{
 		manager_->Update(1);
 	}
-	manager_->Update(0);
+	if (int(deltaFrames) == 0) manager_->Update(0);
 }
 
 int EffekseerManagerCore::Play(EffekseerEffectCore* effect)


### PR DESCRIPTION
Effects are rendered at 60 fps, but the actual rendered frame rate may be well over 60. 
In this case, if the effect is constantly transformed, it cannot be updated in time, resulting in the effect not looking smooth.